### PR TITLE
Add Docker build and run scripts for Linux and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,39 @@ CACHE_TIMEOUT=2592000
 python build.py
 ```
 
-### Docker (para desenvolvimento)
-```bash
-docker build -t bitcoin-wallet-core .
-docker run -p 8000:8000 bitcoin-wallet-core
-```
+## Quick Start with Docker
+
+This project can be easily run using Docker. We provide scripts to automate the build and run process.
+
+**Prerequisites:**
+*   Docker: [https://docs.docker.com/engine/install/]
+*   Docker Compose: Usually included with Docker Desktop (Windows, macOS) or installed as a plugin for Docker Engine on Linux. [https://docs.docker.com/compose/install/]
+
+**Instructions:**
+
+### For Linux/macOS Users:
+1.  Open your terminal.
+2.  Navigate to the root directory of this project.
+3.  Make the script executable (if you haven't already):
+    ```bash
+    chmod +x run_docker.sh
+    ```
+4.  Run the script:
+    ```bash
+    ./run_docker.sh
+    ```
+    This script will build the Docker image and start the API service. The API should then be accessible at `http://localhost:8000` (or the port configured in `docker-compose.yml`).
+
+### For Windows Users:
+1.  Open Command Prompt or PowerShell.
+2.  Navigate to the root directory of this project.
+3.  Run the script:
+    ```batch
+    run_docker.bat
+    ```
+    This script will build the Docker image and start the API service. The API should then be accessible at `http://localhost:8000` (or the port configured in `docker-compose.yml`).
+
+---
 
 ## Monitoramento
 

--- a/run_docker.bat
+++ b/run_docker.bat
@@ -1,0 +1,50 @@
+@echo off
+REM Script to build and run the Docker image for bitcoin-wallet-api on Windows
+
+echo Starting the Docker build and run process...
+
+REM Check if Docker is installed and available in the PATH
+docker --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Error: Docker is not installed or not found in PATH. Please install Docker and try again.
+    exit /b 1
+)
+
+REM Check if Docker Compose is installed and available
+set COMPOSE_CMD=
+docker-compose --version >nul 2>&1
+if %errorlevel% equ 0 (
+    set COMPOSE_CMD=docker-compose
+) else (
+    docker compose version >nul 2>&1
+    if %errorlevel% equ 0 (
+        set COMPOSE_CMD=docker compose
+    )
+)
+
+if not defined COMPOSE_CMD (
+    echo Error: Docker Compose is not installed or not found in PATH. Please install Docker Compose and try again.
+    exit /b 1
+)
+
+REM Attempt to build the Docker image
+echo Building the Docker image...
+docker build -t bitcoin-wallet-api .
+if %errorlevel% neq 0 (
+    echo Error: Docker image build failed.
+    exit /b 1
+) else (
+    echo Docker image built successfully.
+)
+
+REM Attempt to start the bitcoin-wallet service using Docker Compose
+echo Starting the bitcoin-wallet service...
+%COMPOSE_CMD% up -d bitcoin-wallet
+if %errorlevel% neq 0 (
+    echo Error: Failed to start the bitcoin-wallet service using %COMPOSE_CMD%.
+    exit /b 1
+)
+
+echo Bitcoin-wallet service started successfully. The API should be accessible.
+
+exit /b 0

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Print a message indicating it's starting the process
+echo "Starting the Docker build and run process..."
+
+# Check if Docker is installed and available in the PATH
+if ! command -v docker &> /dev/null
+then
+    echo "Error: Docker is not installed or not found in PATH. Please install Docker and try again."
+    exit 1
+fi
+
+# Check if Docker Compose is installed and available
+if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null
+then
+    echo "Error: Docker Compose is not installed or not found in PATH. Please install Docker Compose and try again."
+    exit 1
+fi
+
+# Attempt to build the Docker image
+echo "Building the Docker image..."
+if ! docker build -t bitcoin-wallet-api .
+then
+    echo "Error: Docker image build failed."
+    exit 1
+else
+    echo "Docker image built successfully."
+fi
+
+# Attempt to start the bitcoin-wallet service using Docker Compose
+echo "Starting the bitcoin-wallet service..."
+if command -v docker-compose &> /dev/null
+then
+    if ! docker-compose up -d bitcoin-wallet
+    then
+        echo "Error: Failed to start the bitcoin-wallet service using docker-compose."
+        exit 1
+    fi
+elif docker compose version &> /dev/null
+then
+    if ! docker compose up -d bitcoin-wallet
+    then
+        echo "Error: Failed to start the bitcoin-wallet service using docker compose."
+        exit 1
+    fi
+else
+    # This case should ideally not be reached due to the earlier check,
+    # but as a fallback.
+    echo "Error: Docker Compose command not found."
+    exit 1
+fi
+
+echo "Bitcoin-wallet service started successfully. The API should be accessible."
+
+exit 0


### PR DESCRIPTION
This commit introduces two new scripts:
- `run_docker.sh`: A Bash script for Linux and macOS users.
- `run_docker.bat`: A Batch script for Windows users.

These scripts automate the process of:
1. Building the Docker image for the API using the existing Dockerfile.
2. Starting the API service using Docker Compose.

The `README.md` has also been updated to include a "Quick Start with Docker" section, explaining the prerequisites (Docker and Docker Compose) and providing clear instructions on how to use these new scripts on their respective operating systems.

This provides a more user-friendly way for you to get the application running in a Docker environment without needing to manually execute Docker and Docker Compose commands.