### PR TITLE
Fix: Set UTXO script field to None to prevent builder conflicts

### DIFF
--- a/app/services/blockchain_service.py
+++ b/app/services/blockchain_service.py
@@ -288,7 +288,7 @@ def get_utxos(address: str, network: str, offline_mode: bool = False) -> list:
                         "txid": utxo.get("txid"),
                         "vout": utxo.get("vout"),
                         "value": utxo.get("value"),
-                        "script": utxo.get("scriptpubkey", ""),
+                        "script": None,
                         "confirmations": utxo.get("status", {}).get("confirmations", 0),
                         "address": address
                     } for utxo in data]
@@ -300,7 +300,7 @@ def get_utxos(address: str, network: str, offline_mode: bool = False) -> list:
                         "txid": utxo.get("transaction_hash"),
                         "vout": utxo.get("index"),
                         "value": utxo.get("value"),
-                        "script": utxo.get("script_hex", ""),
+                        "script": None,
                         "confirmations": data.get("context", {}).get("state", 0) - utxo.get("block_id", 0) if utxo.get("block_id", 0) > 0 else 0,
                         "address": address
                     } for utxo in data.get("data", {}).get(address, {}).get("utxo", [])]
@@ -312,7 +312,7 @@ def get_utxos(address: str, network: str, offline_mode: bool = False) -> list:
                         "txid": utxo.get("txid"),
                         "vout": utxo.get("vout"),
                         "value": utxo.get("value"),
-                        "script": utxo.get("scriptpubkey", ""),
+                        "script": None,
                         "confirmations": 1 if utxo.get("status", {}).get("confirmed", False) else 0,
                         "address": address
                     } for utxo in data]


### PR DESCRIPTION
I modified the UTXO parsers in `app/services/blockchain_service.py` for blockstream.info, blockchair.com, and mempool.space. The `script` field in the parsed UTXO data is now explicitly set to `None`.

Previously, the `scriptpubkey` (or `script_hex`) from these providers was being populated into the `Input.script` field. Transaction builders (BitcoinCoreBuilder, BitcoinLibBuilder) generally expect this field to be an unlocking script (scriptSig) or to be omitted for standard transactions where scripts can be derived from your address (e.g., SegWit).

Populating `Input.script` with the `scriptPubKey` (a locking script) caused conflicts with the builders' internal logic, leading to errors (observed as 422 Unprocessable Content) when attempting to build transactions using UTXOs from these providers.

Setting the script to `None` allows the builders to correctly apply their default script generation logic, resolving the issue for standard address types.