### PR TITLE
Fix: Refine UTXO script handling for BalanceModel and TxBuilders

### DIFF
--- a/app/services/blockchain_service.py
+++ b/app/services/blockchain_service.py
@@ -288,7 +288,7 @@ def get_utxos(address: str, network: str, offline_mode: bool = False) -> list:
                         "txid": utxo.get("txid"),
                         "vout": utxo.get("vout"),
                         "value": utxo.get("value"),
-                        "script": None,
+                        "script": utxo.get("scriptpubkey", ""),
                         "confirmations": utxo.get("status", {}).get("confirmations", 0),
                         "address": address
                     } for utxo in data]
@@ -300,7 +300,7 @@ def get_utxos(address: str, network: str, offline_mode: bool = False) -> list:
                         "txid": utxo.get("transaction_hash"),
                         "vout": utxo.get("index"),
                         "value": utxo.get("value"),
-                        "script": None,
+                        "script": utxo.get("script_hex", ""),
                         "confirmations": data.get("context", {}).get("state", 0) - utxo.get("block_id", 0) if utxo.get("block_id", 0) > 0 else 0,
                         "address": address
                     } for utxo in data.get("data", {}).get(address, {}).get("utxo", [])]
@@ -312,7 +312,7 @@ def get_utxos(address: str, network: str, offline_mode: bool = False) -> list:
                         "txid": utxo.get("txid"),
                         "vout": utxo.get("vout"),
                         "value": utxo.get("value"),
-                        "script": None,
+                        "script": utxo.get("scriptpubkey", ""),
                         "confirmations": 1 if utxo.get("status", {}).get("confirmed", False) else 0,
                         "address": address
                     } for utxo in data]

--- a/app/services/transaction/tx_builder_service.py
+++ b/app/services/transaction/tx_builder_service.py
@@ -51,6 +51,10 @@ def build_transaction(tx_request: TransactionRequest, network: str, builder_type
                 else:
                     outputs.append(o)
             tx_request.outputs = outputs
+
+        # Ensure inputs passed to builders do not contain scriptpubkey
+        for input_tx in tx_request.inputs:
+            input_tx.script = None
         
         if builder_type.lower() == "bitcoincore":
             tx_builder = BitcoinCoreBuilder()


### PR DESCRIPTION
This commit addresses issues related to the 'script' field in UTXOs:

1. Adjusted `app/services/blockchain_service.py`:
   - UTXO parsers (blockstream, blockchair, mempool.space) now ensure the 'script' field is always a string (e.g., `scriptpubkey` or an empty string `""` if unavailable from the API).
   - This resolves a `ValidationError` in `BalanceModel` which requires `UTXOModel.script` to be a non-optional string.

2. Modified `app/services/transaction/tx_builder_service.py`:
   - Before passing inputs to transaction builders (`BitcoinCoreBuilder`, `BitcoinLibBuilder`), the `script` attribute of each input is explicitly set to `None`.
   - This prevents builders from misinterpreting the `scriptpubkey` (now a string from `blockchain_service`) as an unlocking script, which was the cause of original transaction building errors (422).

These changes ensure that UTXO data satisfies `BalanceModel` requirements while also providing transaction builders with inputs in the format they expect (i.e., without `scriptpubkey` in the `script` field).