### PR TITLE
Fix: Set input script to empty string for transaction builders

### DIFF
--- a/app/services/transaction/tx_builder_service.py
+++ b/app/services/transaction/tx_builder_service.py
@@ -54,7 +54,7 @@ def build_transaction(tx_request: TransactionRequest, network: str, builder_type
 
         # Ensure inputs passed to builders do not contain scriptpubkey
         for input_tx in tx_request.inputs:
-            input_tx.script = None
+            input_tx.script = ""
         
         if builder_type.lower() == "bitcoincore":
             tx_builder = BitcoinCoreBuilder()


### PR DESCRIPTION
Further refines UTXO script handling for `/api/tx/build`.

In `app/services/transaction/tx_builder_service.py`, the `script` attribute of each input in a `TransactionRequest` is now explicitly set to an empty string (`""`) before being passed to the transaction builders.

Previously, it was set to `None`. While `None` is also falsy and should have been ignored by builders, changing to an empty string `""` ensures the `script` attribute remains typed as a string consistently after Pydantic model instantiation. This may help avoid potential subtle issues with Pydantic model re-validation or type-sensitive operations that could have contributed to the persistent 422 error on the `/api/tx/build` endpoint.

An empty string script is falsy, so builders (`BitcoinCoreBuilder`, `BitcoinLibBuilder`) will ignore it and use their default logic based on the input's address, which is the desired behavior. This change, combined with ensuring `blockchain_service.py` provides string scripts (e.g. scriptpubkey or `""`) for `BalanceModel`, aims to resolve all previously observed validation and transaction building errors.